### PR TITLE
fix score.py bug

### DIFF
--- a/task1/baseline/README.md
+++ b/task1/baseline/README.md
@@ -46,7 +46,7 @@ Found no errors, output file is valid
 
 * Evaluate the output.
 ``` shell
-$ python3 scripts/scores.py --dataset val --dataroot data --outfile baseline/DSTC10_DST/DST_preds.json --scorefile baseline.val.score.json
+$ python3 scripts/scores.py --dataset val --dataroot data --outfile baseline/DSTC10_DST/DST_preds.json --scorefile baseline.val.score.json --K 5
 ```
 
 * Print out the scores.

--- a/task1/scripts/scores.py
+++ b/task1/scripts/scores.py
@@ -70,7 +70,7 @@ class Metric:
 
         return result
                     
-    def update(self, ref_obj, pred_obj):
+    def update(self, ref_obj, pred_obj, K=None):
         joint_goal_flag = True
         
         for key1, key2, key3 in slot_keys:
@@ -101,6 +101,7 @@ class Metric:
                 joint_goal_flag = False                
             else:
                 self._slot_none_tn += 1.0
+                pred_val = pred_val[:K]
                 
                 matched = False
                 for r in ref_val:
@@ -185,6 +186,8 @@ def main(argv):
                         help='File containing output JSON')
     parser.add_argument('--scorefile',dest='scorefile',action='store',metavar='JSON_FILE',required=True,
                         help='File containing scores')
+    parser.add_argument('--K', dest='K',action='store',metavar='NUMBER',required=True, type=int, 
+                        help='the maximal length of predicted value corresponding to each slot')
 
     args = parser.parse_args()
 
@@ -196,7 +199,7 @@ def main(argv):
     metric = Metric()
 
     for (instance, ref), pred in zip(data, output):
-        metric.update(ref, pred)
+        metric.update(ref, pred, args.K)
         
     scores = metric.scores()
 


### PR DESCRIPTION
# Question about task1
There may be a bug in line 106 of the file `score.py`. We think we should limit the maximum list length of `pred_val` to `K` here, while now the list of predictions could be infinitely long. It is possible to use brute force method to keep `pred_val` right, affect the fairness of the competition.

# Suggestion
We update the file `score.py` by adding parameter `K` to limit the length of `pred_val`. Details can be seen in `task1/baseline/README.md` and `task1/scripts/scores.py`